### PR TITLE
Fix prefectural scraper output handling

### DIFF
--- a/etl/fetch_pref_pages.py
+++ b/etl/fetch_pref_pages.py
@@ -1,6 +1,34 @@
-from datetime import datetime, timezone
+import argparse
+import hashlib
+import json
 import re
-from requests.adapters import HTTPAdapter, Retry
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List
+from urllib.parse import urljoin
+
+import requests
+import yaml
+from bs4 import BeautifulSoup
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent / "config"
+
+
+def available_prefs() -> List[str]:
+    prefs: List[str] = []
+    for path in CONFIG_DIR.glob("sources_*.yml"):
+        stem = path.stem
+        if stem == "sources_common":
+            continue
+        pref = stem.replace("sources_", "", 1).strip()
+        if pref:
+            prefs.append(pref)
+    return sorted(set(prefs))
+
 
 SESSION = requests.Session()
 SESSION.headers.update({"User-Agent": "eucalia-pref-scraper/1.0"})
@@ -9,7 +37,8 @@ SESSION.mount("https://", HTTPAdapter(max_retries=Retry(
 )))
 
 def read_cfg(pref):
-    with open(f"config/sources_{pref}.yml", "r", encoding="utf-8") as f:
+    path = CONFIG_DIR / f"sources_{pref}.yml"
+    with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 def is_pdf_link(a_tag, href, selectors):
@@ -79,22 +108,94 @@ def scrape_page(base_url, selectors):
 
     return updated_raw, updated_iso, out_links
 
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Scrape prefectural grant pages defined in config/sources_*.yml")
+    parser.add_argument("--out", required=True, help="出力JSONLファイルパス")
+    parser.add_argument("--prefs", nargs="*", default=None,
+                        help="取得対象の都道府県コード（例: tokyo kanagawa）。未指定時は全件")
+    parser.add_argument("--sleep", type=float, default=0.2,
+                        help="ページ間スリープ秒（デフォルト0.2s）")
+    return parser.parse_args()
+
+
+def ensure_output_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
 def main():
-    ...
-    for page in meta.get("pages", []):
+    args = parse_args()
+    prefs = args.prefs or available_prefs()
+
+    if not prefs:
+        print("[ERROR] No prefecture configs found.", file=sys.stderr)
+        return
+
+    rows: List[Dict] = []
+    for pref in prefs:
         try:
-            updated_raw, updated_iso, links = scrape_page(page["url"], page["selectors"])
-        except Exception as e:
-            print(f"[WARN] failed: {page['url']} ({e})")
+            meta = read_cfg(pref)
+        except FileNotFoundError:
+            print(f"[WARN] config not found for pref='{pref}'", file=sys.stderr)
             continue
-        rows.append({
-            "id": hashlib.sha256(f"{meta.get('publisher')}-{page['url']}-{updated_iso}".encode("utf-8")).hexdigest(),
-            "publisher": meta.get("publisher"),
-            "geography": meta.get("geography_code"),
-            "source_url": page["url"],
-            "page_name": page["name"],
-            "updated_hint_raw": updated_raw,
-            "updated_at": updated_iso,
-            "pdf_links": links,  # PDFのみに絞る
-            "fetched_at": datetime.now(timezone.utc).isoformat(),
-        })
+        except yaml.YAMLError as e:
+            print(f"[WARN] failed to parse config for pref='{pref}': {e}", file=sys.stderr)
+            continue
+
+        publisher = meta.get("publisher")
+        geography = meta.get("geography_code") or meta.get("geography")
+        for page in meta.get("pages", []):
+            url = page.get("url")
+            if not url:
+                continue
+            selectors = page.get("selectors") or {}
+            try:
+                updated_raw, updated_iso, links = scrape_page(url, selectors)
+            except Exception as e:  # noqa: BLE001
+                print(f"[WARN] failed: {url} ({e})", file=sys.stderr)
+                continue
+
+            row = {
+                "id": hashlib.sha256(f"{publisher}-{url}-{updated_iso}".encode("utf-8")).hexdigest(),
+                "publisher": publisher,
+                "geography": geography,
+                "source_url": url,
+                "page_name": page.get("name"),
+                "updated_hint_raw": updated_raw,
+                "updated_at": updated_iso,
+                "pdf_links": links,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+            }
+            rows.append(row)
+
+            if args.sleep and args.sleep > 0:
+                time.sleep(args.sleep)
+
+    if not rows:
+        out_path = Path(args.out)
+        ensure_output_dir(out_path)
+        out_path.write_text("", encoding="utf-8")
+        print(f"[INFO] wrote 0 rows to {out_path}")
+        return
+
+    unique = {}
+    for row in rows:
+        unique.setdefault(row["id"], row)
+
+    ordered_rows = sorted(unique.values(), key=lambda r: (
+        r.get("publisher") or "",
+        r.get("page_name") or "",
+        r.get("source_url") or "",
+    ))
+
+    out_path = Path(args.out)
+    ensure_output_dir(out_path)
+    with out_path.open("w", encoding="utf-8") as f:
+        for row in ordered_rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    print(f"[DONE] wrote {len(ordered_rows)} rows to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/etl/fetch_pref_pages.py
+++ b/etl/fetch_pref_pages.py
@@ -6,7 +6,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, Iterable, List, Optional
 from urllib.parse import urljoin
 
 import requests
@@ -32,9 +32,16 @@ def available_prefs() -> List[str]:
 
 SESSION = requests.Session()
 SESSION.headers.update({"User-Agent": "eucalia-pref-scraper/1.0"})
-SESSION.mount("https://", HTTPAdapter(max_retries=Retry(
-    total=3, backoff_factor=0.5, status_forcelist=[429,500,502,503,504]
-)))
+SESSION.mount(
+    "https://",
+    HTTPAdapter(
+        max_retries=Retry(
+            total=3,
+            backoff_factor=0.5,
+            status_forcelist=[429, 500, 502, 503, 504],
+        )
+    ),
+)
 
 def read_cfg(pref):
     path = CONFIG_DIR / f"sources_{pref}.yml"
@@ -78,8 +85,8 @@ def parse_updated(text):
     iso = dt.replace(tzinfo=timezone.utc).isoformat() if dt else None
     return raw, iso
 
-def scrape_page(base_url, selectors):
-    r = SESSION.get(base_url, timeout=30)
+def scrape_page(base_url, selectors, session: requests.Session = SESSION):
+    r = session.get(base_url, timeout=30)
     r.encoding = r.apparent_encoding or r.encoding
     r.raise_for_status()
     try:
@@ -109,28 +116,43 @@ def scrape_page(base_url, selectors):
     return updated_raw, updated_iso, out_links
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(description="Scrape prefectural grant pages defined in config/sources_*.yml")
+def parse_args(argv: Optional[Iterable[str]] = None):
+    parser = argparse.ArgumentParser(
+        description="Scrape prefectural grant pages defined in config/sources_*.yml"
+    )
     parser.add_argument("--out", required=True, help="出力JSONLファイルパス")
-    parser.add_argument("--prefs", nargs="*", default=None,
-                        help="取得対象の都道府県コード（例: tokyo kanagawa）。未指定時は全件")
-    parser.add_argument("--sleep", type=float, default=0.2,
-                        help="ページ間スリープ秒（デフォルト0.2s）")
-    return parser.parse_args()
+    parser.add_argument(
+        "--prefs",
+        nargs="*",
+        default=None,
+        help="取得対象の都道府県コード（例: tokyo kanagawa）。未指定時は全件",
+    )
+    parser.add_argument(
+        "--sleep",
+        type=float,
+        default=0.2,
+        help="ページ間スリープ秒（デフォルト0.2s）",
+    )
+    parser.add_argument(
+        "--preview",
+        nargs="?",
+        const=5,
+        type=int,
+        help="完了後にJSONLの先頭N件を表示（省略時は5件）",
+    )
+    return parser.parse_args(argv)
 
 
 def ensure_output_dir(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
 
-def main():
-    args = parse_args()
-    prefs = args.prefs or available_prefs()
-
-    if not prefs:
-        print("[ERROR] No prefecture configs found.", file=sys.stderr)
-        return
-
+def collect_rows(
+    prefs: Iterable[str],
+    *,
+    session: requests.Session = SESSION,
+    sleep: float = 0.2,
+) -> List[Dict]:
     rows: List[Dict] = []
     for pref in prefs:
         try:
@@ -139,7 +161,10 @@ def main():
             print(f"[WARN] config not found for pref='{pref}'", file=sys.stderr)
             continue
         except yaml.YAMLError as e:
-            print(f"[WARN] failed to parse config for pref='{pref}': {e}", file=sys.stderr)
+            print(
+                f"[WARN] failed to parse config for pref='{pref}': {e}",
+                file=sys.stderr,
+            )
             continue
 
         publisher = meta.get("publisher")
@@ -150,13 +175,17 @@ def main():
                 continue
             selectors = page.get("selectors") or {}
             try:
-                updated_raw, updated_iso, links = scrape_page(url, selectors)
+                updated_raw, updated_iso, links = scrape_page(
+                    url, selectors, session=session
+                )
             except Exception as e:  # noqa: BLE001
                 print(f"[WARN] failed: {url} ({e})", file=sys.stderr)
                 continue
 
             row = {
-                "id": hashlib.sha256(f"{publisher}-{url}-{updated_iso}".encode("utf-8")).hexdigest(),
+                "id": hashlib.sha256(
+                    f"{publisher}-{url}-{updated_iso}".encode("utf-8")
+                ).hexdigest(),
                 "publisher": publisher,
                 "geography": geography,
                 "source_url": url,
@@ -168,34 +197,91 @@ def main():
             }
             rows.append(row)
 
-            if args.sleep and args.sleep > 0:
-                time.sleep(args.sleep)
+            if sleep and sleep > 0:
+                time.sleep(sleep)
+    return rows
 
-    if not rows:
-        out_path = Path(args.out)
-        ensure_output_dir(out_path)
-        out_path.write_text("", encoding="utf-8")
-        print(f"[INFO] wrote 0 rows to {out_path}")
-        return
 
+def dedupe_and_order_rows(rows: Iterable[Dict]) -> List[Dict]:
     unique = {}
     for row in rows:
         unique.setdefault(row["id"], row)
 
-    ordered_rows = sorted(unique.values(), key=lambda r: (
-        r.get("publisher") or "",
-        r.get("page_name") or "",
-        r.get("source_url") or "",
-    ))
+    return sorted(
+        unique.values(),
+        key=lambda r: (
+            r.get("publisher") or "",
+            r.get("page_name") or "",
+            r.get("source_url") or "",
+        ),
+    )
 
-    out_path = Path(args.out)
+
+def write_output(rows: Iterable[Dict], out_path: Path) -> Path:
     ensure_output_dir(out_path)
+    ordered_rows = list(rows)
+    if not ordered_rows:
+        out_path.write_text("", encoding="utf-8")
+        print(f"[INFO] wrote 0 rows to {out_path}")
+        return out_path
+
     with out_path.open("w", encoding="utf-8") as f:
         for row in ordered_rows:
             f.write(json.dumps(row, ensure_ascii=False) + "\n")
 
     print(f"[DONE] wrote {len(ordered_rows)} rows to {out_path}")
+    return out_path
+
+
+def preview_output(out_path: Path, limit: int) -> None:
+    limit = max(0, limit)
+    print(f"[PREVIEW] showing up to {limit} rows from {out_path}")
+    lines = out_path.read_text(encoding="utf-8").splitlines()
+    if not lines:
+        print("[PREVIEW] <empty>")
+        return
+
+    for line in lines[:limit]:
+        print(line)
+
+    if limit < len(lines):
+        print(f"[PREVIEW] ... ({len(lines) - limit} more rows)")
+
+
+def run(
+    out_path: Path,
+    *,
+    prefs: Optional[Iterable[str]] = None,
+    sleep: float = 0.2,
+    preview: Optional[int] = None,
+    session: requests.Session = SESSION,
+) -> Path:
+    pref_list = list(prefs or available_prefs())
+    if not pref_list:
+        print("[ERROR] No prefecture configs found.", file=sys.stderr)
+        return out_path
+
+    rows = collect_rows(pref_list, session=session, sleep=sleep)
+    ordered_rows = dedupe_and_order_rows(rows)
+    result_path = write_output(ordered_rows, out_path)
+
+    if preview is not None:
+        preview_output(result_path, preview)
+
+    return result_path
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+    run(
+        Path(args.out),
+        prefs=args.prefs,
+        sleep=args.sleep,
+        preview=args.preview,
+        session=SESSION,
+    )
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_fetch_pref_pages.py
+++ b/tests/test_fetch_pref_pages.py
@@ -1,0 +1,137 @@
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from etl import fetch_pref_pages
+
+
+class DummyResponse:
+    def __init__(self, text: str):
+        self.text = text
+        self.status_code = 200
+        self.encoding = "utf-8"
+        self.apparent_encoding = "utf-8"
+
+    def raise_for_status(self) -> None:  # pragma: no cover - simple stub
+        return
+
+
+class DummySession:
+    def __init__(self, html_by_url):
+        self.html_by_url = html_by_url
+        self.requested_urls = []
+
+    def get(self, url, timeout=30):
+        self.requested_urls.append((url, timeout))
+        return DummyResponse(self.html_by_url[url])
+
+
+def write_config(tmp_path: Path, name: str, data: dict) -> Path:
+    config_path = tmp_path / f"sources_{name}.yml"
+    config_path.write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
+    return config_path
+
+
+def test_run_creates_output_and_preview(tmp_path, monkeypatch, capsys):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    write_config(
+        config_dir,
+        "demo",
+        {
+            "publisher": "Demo Pref",
+            "geography": "JP-00",
+            "pages": [
+                {
+                    "name": "Support",
+                    "url": "https://example.com/support/",
+                    "selectors": {
+                        "links": "a.doc",
+                        "updated_at": ".updated",
+                    },
+                }
+            ],
+        },
+    )
+
+    html = """
+    <html>
+      <body>
+        <div class="updated">2024/04/01</div>
+        <a class="doc" href="files/info.pdf">Guideline PDF</a>
+        <a class="doc" href="files/ignore.txt">Ignored text</a>
+      </body>
+    </html>
+    """
+    session = DummySession({"https://example.com/support/": html})
+
+    monkeypatch.setattr(fetch_pref_pages, "CONFIG_DIR", config_dir)
+
+    out_path = tmp_path / "out" / "result.jsonl"
+
+    fetch_pref_pages.run(
+        out_path,
+        prefs=["demo"],
+        sleep=0,
+        preview=2,
+        session=session,
+    )
+
+    captured = capsys.readouterr()
+    assert "[DONE] wrote 1 rows" in captured.out
+    assert "[PREVIEW] showing up to 2 rows" in captured.out
+
+    assert out_path.exists()
+    lines = out_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+
+    assert record["publisher"] == "Demo Pref"
+    assert record["pdf_links"] == [
+        {
+            "url": "https://example.com/support/files/info.pdf",
+            "text": "Guideline PDF",
+        }
+    ]
+    assert record["updated_at"] == "2024-04-01T00:00:00+00:00"
+    assert "fetched_at" in record
+
+    assert session.requested_urls == [("https://example.com/support/", 30)]
+
+
+def test_run_with_no_rows_creates_empty_file_and_preview(tmp_path, monkeypatch, capsys):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    write_config(
+        config_dir,
+        "empty",
+        {
+            "publisher": "Empty Pref",
+            "geography": "JP-99",
+            "pages": [],
+        },
+    )
+
+    monkeypatch.setattr(fetch_pref_pages, "CONFIG_DIR", config_dir)
+
+    out_path = tmp_path / "out" / "empty.jsonl"
+
+    fetch_pref_pages.run(
+        out_path,
+        prefs=["empty"],
+        sleep=0,
+        preview=3,
+    )
+
+    captured = capsys.readouterr()
+    assert "[INFO] wrote 0 rows" in captured.out
+    assert "[PREVIEW] <empty>" in captured.out
+
+    assert out_path.exists()
+    assert out_path.read_text(encoding="utf-8") == ""


### PR DESCRIPTION
## Summary
- add CLI argument parsing and configuration discovery to `fetch_pref_pages.py`
- ensure prefectural scraper writes deterministic JSONL output (even when no rows) and logs warnings gracefully
- import `Retry` from `urllib3.util.retry` to avoid relying on the Requests re-export

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c90c5f99248325821eb30769263be3