### PR TITLE
Refine normalization schema and compress artifacts

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: 'pip'
+          cache: pip
       - run: pip install -r requirements.txt
       - name: Fetch jGrants
         run: python etl/fetch_jgrants.py --out data/jgrants.jsonl
@@ -27,18 +27,22 @@ jobs:
         run: python etl/normalize.py data/*.jsonl --out data/normalized.parquet
       - name: Dedupe & Events
         run: python etl/dedupe_and_events.py data/normalized.parquet --out data/events.parquet
+      - name: Prepare compressed artifacts
+        run: |
+          gzip -c data/normalized.parquet > data/normalized.parquet.gz
+          gzip -c data/events.parquet > data/events.parquet.gz
       - name: Authenticate to Google Cloud
         env:
           GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
         if: env.GCP_PROJECT != ''
-        uses: 'google-github-actions/auth@v2'
+        uses: google-github-actions/auth@v2
         with:
-          credentials_json: '${{ secrets.GCP_SA_JSON }}'
+          credentials_json: ${{ secrets.GCP_SA_JSON }}
       - name: Load to BigQuery
         env:
           GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
-          BQ_DATASET:  grants_hc
-          BQ_TABLE:    programs
+          BQ_DATASET: grants_hc
+          BQ_TABLE: programs
         if: env.GCP_PROJECT != ''
         run: python etl/load_bq.py data/events.parquet
       - name: Notify (Slack/Email)
@@ -46,8 +50,10 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         if: env.SLACK_WEBHOOK != ''
         run: python etl/notify.py --mode weekly_digest
-      - name: Upload all data artifacts
+      - name: Upload normalized artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: all-data-artifacts
-          path: data/
+          name: normalized-artifacts
+          path: |
+            data/normalized.parquet.gz
+            data/events.parquet.gz

--- a/etl/dedupe_and_events.py
+++ b/etl/dedupe_and_events.py
@@ -1,22 +1,90 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import argparse
-import pandas as pd
 import hashlib
-import numpy as np
+import json
+import re
+from typing import Any
 
-def normalize_text(s: pd.Series) -> pd.Series:
-    # 欠損→空文字、前後空白削除、全角空白→半角、大小無視
-    s = s.fillna("").astype(str)
-    s = s.str.replace("\u3000", " ", regex=False).str.strip().str.lower()
-    # 連続空白を1つに圧縮
-    s = s.str.replace(r"\s+", " ", regex=True)
-    return s
+import numpy as np
+import pandas as pd
+
+SPACE_ZEN = "\u3000"
+DATE_TOKEN_PATTERNS = [
+    re.compile(r"(\d{4})[./-](\d{1,2})[./-](\d{1,2})"),
+    re.compile(r"(\d{4})\s*年\s*(\d{1,2})\s*月\s*(\d{1,2})\s*日?"),
+]
+
+
+def normalize_text(series: pd.Series) -> pd.Series:
+    series = series.fillna("").astype(str)
+    series = series.str.replace(SPACE_ZEN, " ", regex=False).str.strip().str.lower()
+    series = series.str.replace(r"\s+", " ", regex=True)
+    return series
+
 
 def sha1_hex(series: pd.Series) -> pd.Series:
     return series.map(lambda x: hashlib.sha1(x.encode("utf-8")).hexdigest())
 
-def main():
+
+def extract_dates(text: str) -> list[pd.Timestamp]:
+    tokens: list[pd.Timestamp] = []
+    for pat in DATE_TOKEN_PATTERNS:
+        for match in pat.finditer(text):
+            y, mo, d = match.groups()
+            try:
+                dt = pd.Timestamp(year=int(y), month=int(mo), day=int(d), tz="UTC")
+            except ValueError:
+                continue
+            tokens.append(dt)
+    return tokens
+
+
+def parse_period_end(value: Any) -> pd.Timestamp:
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return pd.NaT
+
+    if isinstance(value, pd.Timestamp):
+        return value.tz_convert("UTC") if value.tzinfo else value.tz_localize("UTC")
+
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return pd.NaT
+        return parse_period_end(value[-1])
+
+    if isinstance(value, dict):
+        for key in ("end", "to", "deadline", "finish", "until"):
+            if key in value:
+                result = parse_period_end(value[key])
+                if not pd.isna(result):
+                    return result
+        for key in ("start", "from"):
+            if key in value:
+                result = parse_period_end(value[key])
+                if not pd.isna(result):
+                    return result
+        return pd.NaT
+
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return pd.NaT
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            parsed = None
+        if parsed is not None and not isinstance(parsed, str):
+            return parse_period_end(parsed)
+        tokens = extract_dates(text)
+        if tokens:
+            return tokens[-1]
+        dt = pd.to_datetime(text, errors="coerce", utc=True)
+        return dt
+
+    return pd.to_datetime(value, errors="coerce", utc=True)
+
+
+def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("input")
     ap.add_argument("--out", required=True)
@@ -24,49 +92,45 @@ def main():
 
     df = pd.read_parquet(args.input)
 
-    # 必要列が無い場合に備えて作成
-    for col in ["publisher", "fiscal_year", "title"]:
+    required = [
+        "title",
+        "geography",
+        "subsidy_rate",
+        "application_period",
+        "source_url",
+        "subsidy_cap_jpy",
+    ]
+    for col in required:
         if col not in df.columns:
-            df[col] = ""
+            df[col] = pd.NA
 
-    pub = normalize_text(df["publisher"])
-    # Fiscal year may be numeric or missing; normalize_text can handle NaN directly
-    # If we cast to string beforehand, NaN becomes the literal 'nan' and affects
-    # deduplication keys. Pass the original series so missing values stay empty.
-    fy  = normalize_text(df["fiscal_year"])
-    ttl = normalize_text(df["title"])
+    title = normalize_text(df["title"])
+    geography = normalize_text(df["geography"])
+    rate = normalize_text(df["subsidy_rate"])
+    period = normalize_text(df["application_period"])
+    source = normalize_text(df["source_url"])
 
-    key_source = pub + "/" + fy + "/" + ttl
+    cap_numeric = pd.to_numeric(df["subsidy_cap_jpy"], errors="coerce")
+    cap_text = cap_numeric.map(lambda x: "" if pd.isna(x) else str(int(x)))
+
+    key_source = title + "|" + geography + "|" + rate + "|" + cap_text + "|" + period + "|" + source
     df["dedupe_key"] = sha1_hex(key_source)
-
-    # 近傍重複の“近傍”をもう一段見るなら、タイトルを記号除去や
-    # token sort（rapidfuzz）で正規化キーを足してもOK（必要時）
 
     df = df.drop_duplicates(subset=["dedupe_key"], keep="first").copy()
 
-    # イベント化：締切があれば open、無ければ upcoming
-    # 締切が過去なら closed、今日以降なら open 等に分岐
     now_utc = pd.Timestamp.now(tz="UTC").normalize()
-    deadline_col = None
-    for cand in ["deadline", "due_date", "application_deadline"]:
-        if cand in df.columns:
-            deadline_col = cand
-            break
+    deadlines = df["application_period"].apply(parse_period_end)
+    df["status"] = np.where(
+        deadlines.isna(),
+        "upcoming",
+        np.where(deadlines >= now_utc, "open", "closed"),
+    )
 
-    if deadline_col:
-        dl = pd.to_datetime(df[deadline_col], errors="coerce", utc=True)
-        df["status"] = np.where(dl.isna(), "upcoming",
-                         np.where(dl >= now_utc, "open", "closed"))
-    else:
-        # 締切列が無ければ、既存statusが欠損のみ open に
-        if "status" not in df.columns:
-            df["status"] = np.nan
-        df["status"] = df["status"].fillna("open")
-
-    df["last_seen_at"] = pd.Timestamp.now(tz="UTC").isoformat()  # tz-aware (…Z)
+    df["last_seen_at"] = pd.Timestamp.now(tz="UTC").isoformat()
 
     df.to_parquet(args.out, index=False)
     print(f"Wrote {len(df)} rows to {args.out}")
+
 
 if __name__ == "__main__":
     main()

--- a/etl/normalize.py
+++ b/etl/normalize.py
@@ -1,60 +1,40 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-取得データを共通スキーマに正規化（堅牢版）
+取得データを共通スキーマに正規化
 - jGrants / 都道府県ページ / SII等リンク収集 からのJSONL/Parquet入力を統一スキーマに整形
 - 日付のゆらぎ吸収（YYYY/MM/DD, YYYY年M月D日 等）
-- docs_urls_json をJSON文字列に統一
-- content_hash で差分/重複検知を支援
 """
 
 import argparse
 import glob
 import json
-import os
 import re
-import hashlib
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 import pandas as pd
 
 SCHEMA_COLS = [
-    "program_id",
-    "source_url",
-    "publisher",
     "title",
-    "fiscal_year",
-    "domain",
-    "eligibility_json",
-    "geography",
-    "subsidy_rate",
     "subsidy_cap_jpy",
-    "budget_total_jpy",
-    "cost_items_allowed",
-    "deadline_type",
-    "deadline_at",
-    "application_method",
-    "requires_gbizid",
-    "docs_urls_json",
-    "status",
-    "published_at",
-    "last_seen_at",
-    "content_hash",
+    "subsidy_rate",
+    "geography",
+    "employee_limit",
+    "application_period",
+    "source_url",
 ]
-
-# ---------- helpers ----------
 
 SPACE_ZEN = "\u3000"
 DATE_PATTERNS = [
-    # 2025-09-11 / 2025/9/1 / 2025.9.1
     re.compile(r"^\s*(\d{4})[./-]\s*(\d{1,2})[./-]\s*(\d{1,2})\s*$"),
-    # 2025年9月1日
     re.compile(r"^\s*(\d{4})\s*年\s*(\d{1,2})\s*月\s*(\d{1,2})\s*日?\s*$"),
 ]
+DATE_IN_TEXT_PATTERNS = [
+    re.compile(r"(\d{4})[./-](\d{1,2})[./-](\d{1,2})"),
+    re.compile(r"(\d{4})\s*年\s*(\d{1,2})\s*月\s*(\d{1,2})\s*日?"),
+]
 
-def now_utc_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
 
 def normalize_text(s: Optional[str]) -> str:
     if s is None:
@@ -63,24 +43,21 @@ def normalize_text(s: Optional[str]) -> str:
     s = re.sub(r"\s+", " ", s).strip()
     return s
 
+
 def to_str_or_none(x: Any) -> Optional[str]:
     if x is None:
         return None
     s = str(x).strip()
     return s if s else None
 
+
 def parse_ymd_to_iso_utc(x: Any) -> Optional[str]:
-    """
-    YYYY/MM/DD, YYYY-MM-DD, YYYY年M月D日 を UTC midnight ISO8601に。
-    既にISOっぽい場合はそのまま返す（tz欠落時はUTC扱いに統一）。
-    """
     if x is None:
         return None
     s = normalize_text(str(x))
     if not s:
         return None
 
-    # 既にISO8601（ざっくり）ならtz付与（なければUTC）
     if re.match(r"^\d{4}-\d{2}-\d{2}", s):
         try:
             dt = datetime.fromisoformat(s)
@@ -89,8 +66,7 @@ def parse_ymd_to_iso_utc(x: Any) -> Optional[str]:
             else:
                 dt = dt.astimezone(timezone.utc)
             return dt.isoformat()
-        except Exception:
-            # フォールバックで日付部分だけ拾う
+        except Exception:  # noqa: BLE001
             m = re.match(r"^(\d{4})-(\d{2})-(\d{2})", s)
             if m:
                 y, mo, d = map(int, m.groups())
@@ -105,167 +81,367 @@ def parse_ymd_to_iso_utc(x: Any) -> Optional[str]:
             dt = datetime(y, mo, d, tzinfo=timezone.utc)
             return dt.isoformat()
 
-    # ここまでで解釈不能ならNone
     return None
 
-def safe_json_dumps(obj: Any) -> Optional[str]:
-    if obj is None:
-        return None
-    try:
-        return json.dumps(obj, ensure_ascii=False)
-    except Exception:
-        return None
-
-def sha1_of_fields(fields: Iterable[Any]) -> str:
-    raw = "|".join("" if v is None else str(v) for v in fields)
-    return hashlib.sha1(raw.encode("utf-8")).hexdigest()
 
 def ensure_schema(row: Dict[str, Any]) -> Dict[str, Any]:
-    """不足キーをNoneで補完し、順序をSCHEMA_COLSに揃える"""
-    out = {k: row.get(k) for k in SCHEMA_COLS}
+    return {k: row.get(k) for k in SCHEMA_COLS}
+
+
+def get_nested_value(data: Dict[str, Any], key: str) -> Any:
+    parts = key.split(".")
+    cur: Any = data
+    for part in parts:
+        if isinstance(cur, dict):
+            cur = cur.get(part)
+        else:
+            return None
+    return cur
+
+
+def first_non_empty(data: Dict[str, Any], keys: Sequence[str]) -> Any:
+    for key in keys:
+        value = get_nested_value(data, key)
+        if isinstance(value, str):
+            value = value.strip()
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                if item not in (None, ""):
+                    return item
+            continue
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def parse_amount_jpy(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if value != value:  # NaN
+            return None
+        return int(value)
+
+    if isinstance(value, (list, tuple)):
+        parsed = [parse_amount_jpy(v) for v in value]
+        parsed = [v for v in parsed if v is not None]
+        if parsed:
+            return max(parsed)
+        return None
+
+    if not isinstance(value, str):
+        return None
+
+    s = normalize_text(value)
+    if not s:
+        return None
+
+    if any(term in s for term in ["上限なし", "上限無し", "制限なし", "制限無し", "なし", "無し"]):
+        return None
+
+    s = s.replace(",", "")
+    total = 0
+    matched = False
+
+    def _parse_fragment(fragment: str, multiplier: int) -> int:
+        frag = fragment.strip()
+        if not frag:
+            return 0
+        inner = parse_amount_jpy(frag)
+        return 0 if inner is None else inner * multiplier
+
+    for unit, mult in (("億", 100_000_000), ("万", 10_000)):
+        if unit in s:
+            left, right = s.split(unit, 1)
+            total += _parse_fragment(left, mult)
+            s = right
+            matched = True
+
+    m = re.search(r"(-?\d+(?:\.\d+)?)", s)
+    if m:
+        num = float(m.group(1))
+        tail = s[m.end():]
+        multiplier = 1
+        if tail.startswith("千"):
+            multiplier = 1_000
+        total += int(num * multiplier)
+        matched = True
+
+    return total if matched and total > 0 else None
+
+
+def parse_employee_limit(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if value != value:
+            return None
+        return int(value)
+
+    if isinstance(value, (list, tuple)):
+        parsed = [parse_employee_limit(v) for v in value]
+        parsed = [v for v in parsed if v is not None]
+        if parsed:
+            return max(parsed)
+        return None
+
+    if not isinstance(value, str):
+        return None
+
+    s = normalize_text(value)
+    if not s:
+        return None
+    if any(term in s for term in ["制限なし", "制限無し", "上限なし", "上限無し", "なし", "無し"]):
+        return None
+
+    s = s.replace(",", "")
+    m = re.search(r"(\d+)", s)
+    if not m:
+        return None
+    return int(m.group(1))
+
+
+def extract_subsidy_rate(rec: Dict[str, Any]) -> Optional[str]:
+    raw = first_non_empty(
+        rec,
+        [
+            "subsidyRate",
+            "subsidy_rate",
+            "grantRate",
+            "grant_rate",
+            "supportRate",
+            "rate",
+            "benefitRate",
+            "補助率",
+            "助成率",
+        ],
+    )
+    if raw is None:
+        return None
+    if isinstance(raw, (list, tuple)):
+        parts = [normalize_text(str(x)) for x in raw if normalize_text(str(x))]
+        return ", ".join(parts) if parts else None
+    if isinstance(raw, dict):
+        parts = []
+        for key in ["min", "max", "rate", "value"]:
+            val = raw.get(key)
+            if val not in (None, ""):
+                parts.append(normalize_text(str(val)))
+        if parts:
+            return " - ".join(parts)
+        try:
+            return json.dumps(raw, ensure_ascii=False)
+        except Exception:  # noqa: BLE001
+            return None
+    s = normalize_text(str(raw))
+    return s or None
+
+
+def extract_geography(rec: Dict[str, Any]) -> Optional[str]:
+    raw = first_non_empty(
+        rec,
+        [
+            "geography",
+            "geography_code",
+            "prefecture",
+            "prefectures",
+            "region",
+            "regions",
+            "targetRegion",
+            "targetPrefecture",
+            "applicantRegion",
+        ],
+    )
+    if raw is None:
+        return None
+    if isinstance(raw, (list, tuple)):
+        parts = [normalize_text(str(x)) for x in raw if normalize_text(str(x))]
+        return ", ".join(parts) if parts else None
+    return normalize_text(str(raw)) or None
+
+
+def dates_from_text(text: str) -> List[str]:
+    out: List[str] = []
+    for pat in DATE_IN_TEXT_PATTERNS:
+        for m in pat.finditer(text):
+            y, mo, d = m.groups()
+            try:
+                dt = datetime(int(y), int(mo), int(d), tzinfo=timezone.utc)
+            except ValueError:
+                continue
+            out.append(dt.date().isoformat())
     return out
 
-# ---------- normalizers ----------
+
+def normalize_date_string(value: Any) -> Optional[str]:
+    iso = parse_ymd_to_iso_utc(value)
+    if iso:
+        return iso[:10]
+    if isinstance(value, str):
+        dates = dates_from_text(value)
+        if dates:
+            return dates[0]
+    return None
+
+
+def extract_application_period(rec: Dict[str, Any]) -> Optional[str]:
+    start_raw = first_non_empty(
+        rec,
+        [
+            "applicationStartDate",
+            "applicationStart",
+            "application_start",
+            "applicationStartAt",
+            "acceptanceStartDate",
+            "receptionStartDate",
+            "recruitmentStartDate",
+            "applicationPeriod.start",
+            "applicationPeriod.from",
+            "application_period.start",
+            "application_period.from",
+            "period.start",
+        ],
+    )
+    end_raw = first_non_empty(
+        rec,
+        [
+            "applicationDeadline",
+            "applicationEndDate",
+            "deadline",
+            "receptionEndDate",
+            "recruitmentEndDate",
+            "acceptanceEndDate",
+            "applicationPeriod.end",
+            "applicationPeriod.to",
+            "application_period.end",
+            "application_period.to",
+            "period.end",
+        ],
+    )
+
+    period_raw = first_non_empty(
+        rec,
+        [
+            "applicationPeriod",
+            "application_period",
+            "receptionPeriod",
+            "acceptancePeriod",
+            "募集期間",
+        ],
+    )
+
+    start = normalize_date_string(start_raw)
+    end = normalize_date_string(end_raw)
+
+    if isinstance(period_raw, dict):
+        start = start or normalize_date_string(period_raw.get("start") or period_raw.get("from"))
+        end = end or normalize_date_string(period_raw.get("end") or period_raw.get("to"))
+    elif isinstance(period_raw, (list, tuple)) and period_raw:
+        if len(period_raw) >= 2:
+            start = start or normalize_date_string(period_raw[0])
+            end = end or normalize_date_string(period_raw[1])
+    elif isinstance(period_raw, str):
+        dates = dates_from_text(period_raw)
+        if dates:
+            start = start or dates[0]
+            if len(dates) > 1:
+                end = end or dates[-1]
+
+    if start and end:
+        if start == end:
+            return start
+        return f"{start} - {end}"
+    if end:
+        return end
+    if start:
+        return start
+    if isinstance(period_raw, str):
+        clean = normalize_text(period_raw)
+        return clean or None
+    return None
+
 
 def norm_jgrants(rec: Dict[str, Any]) -> Dict[str, Any]:
-    pid = rec.get("id") or rec.get("subsidyId")
-    title = normalize_text(rec.get("title") or rec.get("subsidyTitle"))
-    pub = normalize_text(rec.get("publisherName") or rec.get("ministryName") or "jGrants掲載")
-    url = to_str_or_none(rec.get("publicUrl") or rec.get("detailUrl"))
-    deadline = rec.get("applicationDeadline") or rec.get("deadline")
-    status = to_str_or_none(rec.get("status") or rec.get("publicationStatus"))
-    fy = to_str_or_none(rec.get("fiscalYear"))
+    title = normalize_text(rec.get("title") or rec.get("subsidyTitle")) or None
+    source_url = to_str_or_none(rec.get("publicUrl") or rec.get("detailUrl"))
 
-    deadline_iso = parse_ymd_to_iso_utc(deadline)
+    amount_candidates = [
+        "subsidyCap",
+        "subsidy_cap",
+        "grantUpperLimit",
+        "grantUpper",
+        "limitAmount",
+        "upperLimit",
+        "subsidyLimit",
+        "grantLimit",
+        "supportUpperLimit",
+        "benefitUpperLimit",
+    ]
+    subsidy_cap = parse_amount_jpy(first_non_empty(rec, amount_candidates))
+
+    employee_candidates = [
+        "employeeLimit",
+        "employee_limit",
+        "employeesUpperLimit",
+        "employeeUpperLimit",
+        "employeeNumberUpperLimit",
+        "maxEmployee",
+        "targetEmployeeUpper",
+        "eligibleEmployeeUpper",
+    ]
+    employee_limit = parse_employee_limit(first_non_empty(rec, employee_candidates))
 
     row = dict(
-        program_id=f"jgrants:{pid}" if pid else None,
-        source_url=url,
-        publisher=pub or None,
-        title=title or None,
-        fiscal_year=fy,
-        domain=None,
-        eligibility_json=None,
-        geography=None,
-        subsidy_rate=None,
-        subsidy_cap_jpy=None,
-        budget_total_jpy=None,
-        cost_items_allowed=None,
-        deadline_type="hard" if deadline_iso else None,
-        deadline_at=deadline_iso,
-        application_method="jgrants",
-        requires_gbizid=True,
-        docs_urls_json=None,
-        status=status,
-        published_at=None,
-        last_seen_at=now_utc_iso(),
-        content_hash=None,
-    )
-    # content_hash: 主要差分軸から生成
-    row["content_hash"] = sha1_of_fields(
-        [row["program_id"], row["source_url"], row["title"], row["deadline_at"], row["publisher"]]
+        title=title,
+        subsidy_cap_jpy=subsidy_cap,
+        subsidy_rate=extract_subsidy_rate(rec),
+        geography=extract_geography(rec),
+        employee_limit=employee_limit,
+        application_period=extract_application_period(rec),
+        source_url=source_url,
     )
     return ensure_schema(row)
+
 
 def norm_pref_page(rec: Dict[str, Any]) -> Dict[str, Any]:
     title = normalize_text(rec.get("page_name"))
     url = to_str_or_none(rec.get("source_url"))
-    pub = normalize_text(rec.get("publisher"))
     geo = to_str_or_none(rec.get("geography") or rec.get("geography_code"))
-    # links構造の汎用対応（pdf_links or links）
-    link_list = rec.get("pdf_links", rec.get("links", []))
-    doc_urls = []
-    for link in link_list or []:
-        u = link.get("url") if isinstance(link, dict) else None
-        if isinstance(u, str) and u.strip():
-            doc_urls.append(u.strip())
-
-    # 更新日ヒント（可能なら published_at に）
-    updated_raw = rec.get("updated_at") or rec.get("updated_hint") or rec.get("updated_hint_raw")
-    published_iso = parse_ymd_to_iso_utc(updated_raw)
+    pub = normalize_text(rec.get("publisher"))
 
     row = dict(
-        program_id=None,
-        source_url=url,
-        publisher=pub or None,
-        title=title or None,
-        fiscal_year=None,
-        domain=None,
-        eligibility_json=None,
-        geography=geo,
-        subsidy_rate=None,
+        title=title or pub or None,
         subsidy_cap_jpy=None,
-        budget_total_jpy=None,
-        cost_items_allowed=None,
-        deadline_type=None,
-        deadline_at=None,
-        application_method="direct",
-        requires_gbizid=False,
-        docs_urls_json=safe_json_dumps(doc_urls) if doc_urls else None,
-        status="unknown",
-        published_at=published_iso,
-        last_seen_at=now_utc_iso(),
-        content_hash=None,
-    )
-    row["content_hash"] = sha1_of_fields(
-        [row["source_url"], row["title"], row["publisher"], row["published_at"]]
+        subsidy_rate=None,
+        geography=geo or pub or None,
+        employee_limit=None,
+        application_period=None,
+        source_url=url,
     )
     return ensure_schema(row)
 
+
 def norm_sii_or_links(rec: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    SII等のリンク収集レコードを想定。
-    - source_url は 起点ページ（source_index/canonical/なければurlのドメインルート）を優先
-    - docs_urls_json に実リンクを格納
-    """
-    # 起点URLの候補
     source_index = to_str_or_none(rec.get("source_index"))
     canonical = to_str_or_none(rec.get("canonical"))
     url = to_str_or_none(rec.get("url"))
 
     source_url = source_index or canonical or url
     title = normalize_text(rec.get("page_title") or rec.get("text"))
-    publisher = "SII/関連"
-    domain = "energy"
-
-    # ドキュメントURL（主にPDF）
-    docs = []
-    if url:
-        docs.append(url)
-
-    # 更新ヒント→published_atに
-    updated_hint = rec.get("updated_hint")
-    published_iso = parse_ymd_to_iso_utc(updated_hint)
 
     row = dict(
-        program_id=None,
-        source_url=source_url,
-        publisher=publisher,
         title=title or None,
-        fiscal_year=None,
-        domain=domain,
-        eligibility_json=None,
-        geography=None,
-        subsidy_rate=None,
         subsidy_cap_jpy=None,
-        budget_total_jpy=None,
-        cost_items_allowed=None,
-        deadline_type=None,
-        deadline_at=None,
-        application_method="direct",
-        requires_gbizid=False,
-        docs_urls_json=safe_json_dumps(docs) if docs else None,
-        status="unknown",
-        published_at=published_iso,
-        last_seen_at=now_utc_iso(),
-        content_hash=None,
-    )
-    row["content_hash"] = sha1_of_fields(
-        [row["source_url"], row["title"], row["published_at"]]
+        subsidy_rate=None,
+        geography=None,
+        employee_limit=None,
+        application_period=extract_application_period(rec),
+        source_url=source_url,
     )
     return ensure_schema(row)
 
-# ---------- input readers ----------
 
 def iter_jsonl(path: str) -> Iterable[Dict[str, Any]]:
     with open(path, "r", encoding="utf-8") as f:
@@ -278,10 +454,12 @@ def iter_jsonl(path: str) -> Iterable[Dict[str, Any]]:
             except json.JSONDecodeError:
                 continue
 
+
 def iter_parquet(path: str) -> Iterable[Dict[str, Any]]:
     df = pd.read_parquet(path)
     for rec in df.to_dict(orient="records"):
         yield rec
+
 
 def iter_input(path: str) -> Iterable[Dict[str, Any]]:
     low = path.lower()
@@ -290,27 +468,20 @@ def iter_input(path: str) -> Iterable[Dict[str, Any]]:
     elif low.endswith(".parquet"):
         yield from iter_parquet(path)
     else:
-        # 他形式は無視（将来拡張余地）
         return
 
-# ---------- detect & normalize ----------
 
 def classify_and_normalize(rec: Dict[str, Any]) -> Dict[str, Any]:
-    # 都道府県ページ
     if ("links" in rec or "pdf_links" in rec) and ("page_name" in rec or "publisher" in rec):
         return norm_pref_page(rec)
-    # jGrants
     if ("id" in rec or "subsidyId" in rec) or ("publicUrl" in rec or "detailUrl" in rec):
         return norm_jgrants(rec)
-    # SIIやその他リンク収集
     if "url" in rec and (("source_index" in rec) or ("text" in rec)):
         return norm_sii_or_links(rec)
-    # フォールバック（最小限）
     return norm_sii_or_links(rec)
 
-# ---------- main ----------
 
-def main():
+def main() -> None:
     ap = argparse.ArgumentParser(description="Normalize harvested records to a common schema.")
     ap.add_argument("inputs", nargs="+", help="Input file globs (.jsonl/.ndjson/.parquet)")
     ap.add_argument("--out", required=True, help="Output Parquet file")
@@ -328,7 +499,6 @@ def main():
             rows.append(row)
 
     if not rows:
-        # 空でもスキーマ列で空DFを書き出しておくと下流が楽
         df_empty = pd.DataFrame([], columns=SCHEMA_COLS)
         df_empty.to_parquet(args.out, index=False)
         print(f"Wrote 0 rows to {args.out}")
@@ -336,19 +506,15 @@ def main():
 
     df = pd.DataFrame(rows, columns=SCHEMA_COLS)
 
-    # 軽い重複排除：
-    # 1) program_id があるものは program_id でユニーク化
-    # 2) program_id 無しは (source_url, title, deadline_at) でユニーク化
-    has_pid = df["program_id"].notna()
-    df_pid = df[has_pid].drop_duplicates(subset=["program_id"], keep="first")
-    df_nopid = df[~has_pid].drop_duplicates(
-        subset=["source_url", "title", "deadline_at"], keep="first"
-    )
-    df = pd.concat([df_pid, df_nopid], ignore_index=True)
+    for col in ["subsidy_cap_jpy", "employee_limit"]:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce").astype("Int64")
 
-    # 出力
+    df = df.drop_duplicates(subset=["source_url", "title", "application_period"], keep="first")
+
     df.to_parquet(args.out, index=False)
     print(f"Wrote {len(df)} rows to {args.out}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- limit normalized grant records to the new lightweight schema and add heuristics to extract subsidy caps, employee limits, and application periods
- align deduplication and event status generation with the reduced column set
- gzip the normalized parquet outputs before uploading artifacts in the daily workflow

## Testing
- python -m compileall etl
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c931de26cc8325a4fd9bcf1b989abb