### PR TITLE
Compress JSONL outputs in daily workflow artifacts

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -29,6 +29,10 @@ jobs:
         run: python etl/dedupe_and_events.py data/normalized.parquet --out data/events.parquet
       - name: Prepare compressed artifacts
         run: |
+          shopt -s nullglob
+          for jsonl in data/*.jsonl; do
+            gzip -c "$jsonl" > "$jsonl.gz"
+          done
           gzip -c data/normalized.parquet > data/normalized.parquet.gz
           gzip -c data/events.parquet > data/events.parquet.gz
       - name: Authenticate to Google Cloud
@@ -55,5 +59,6 @@ jobs:
         with:
           name: normalized-artifacts
           path: |
+            data/*.jsonl.gz
             data/normalized.parquet.gz
             data/events.parquet.gz


### PR DESCRIPTION
## Summary
- gzip each harvested JSONL file during the daily ingestion workflow so raw extracts are stored alongside normalized outputs
- include the new JSONL archives in the uploaded artifact to retain both extraction and normalized data

## Testing
- `bash -lc 'shopt -s nullglob; for jsonl in data/*.jsonl; do gzip -c "$jsonl" > "$jsonl.gz"; done; gzip -c data/normalized.parquet > data/normalized.parquet.gz; gzip -c data/events.parquet > data/events.parquet.gz'`
- `ls data/*.jsonl.gz data/*.parquet.gz`


------
https://chatgpt.com/codex/tasks/task_e_68cbbe027ba083259e863be9bae87ea3